### PR TITLE
allow installation via setup.py

### DIFF
--- a/virtualbmc/__init__.py
+++ b/virtualbmc/__init__.py
@@ -10,10 +10,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import exception
-from virtualbmc import VirtualBMC
-from manager import VirtualBMCManager
-
 version = '0.0.4'
 
-__all__ = ['version', 'exception', 'VirtualBMC', 'VirtualBMCManager']
+__all__ = ['version']

--- a/virtualbmc/cmd/vbmc.py
+++ b/virtualbmc/cmd/vbmc.py
@@ -19,7 +19,7 @@ from prettytable import PrettyTable
 
 from virtualbmc import exception
 from virtualbmc import version
-from virtualbmc import VirtualBMCManager
+from virtualbmc.manager import VirtualBMCManager
 
 
 def main():

--- a/virtualbmc/manager.py
+++ b/virtualbmc/manager.py
@@ -85,6 +85,7 @@ class VirtualBMCManager(object):
     def add(self, username, password, port, address, domain_name, libvirt_uri,
             libvirt_sasl_username, libvirt_sasl_password):
 
+        import pdb; pdb.set_trace()
         # check libvirt's connection and if domain exist prior to adding it
         utils.check_libvirt_connection_and_domain(
             libvirt_uri, domain_name,


### PR DESCRIPTION
this commits permits 'python setup.py install' or 'python setup.py
develop' to run without error, but removing imports from
`virtualbmc/__init__.py`
